### PR TITLE
2.6 add startup probe to camel web service

### DIFF
--- a/tavros/camel-web-service/Chart.yaml
+++ b/tavros/camel-web-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/tavros/camel-web-service/Chart.yaml
+++ b/tavros/camel-web-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/tavros/camel-web-service/templates/deployment.yaml
+++ b/tavros/camel-web-service/templates/deployment.yaml
@@ -60,6 +60,8 @@ spec:
           livenessProbe:
             {{- toYaml . | nindent 12 }}
         {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: JAEGER_SERVICE_NAME
               value: {{ .Release.Name }}

--- a/tavros/camel-web-service/templates/deployment.yaml
+++ b/tavros/camel-web-service/templates/deployment.yaml
@@ -60,6 +60,10 @@ spec:
           livenessProbe:
             {{- toYaml . | nindent 12 }}
         {{- end }}
+        {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:

--- a/tavros/camel-web-service/values.yaml
+++ b/tavros/camel-web-service/values.yaml
@@ -53,6 +53,14 @@ livenessProbe:
   initialDelaySeconds: 60
   periodSeconds: 10
 
+startupProbe:
+  httpGet:
+    path: /actuator/health/liveness
+    port: actuator
+  failureThreshold: 6
+  initialDelaySeconds: 60
+  periodSeconds: 10
+
 resources: {}
 #   limits:
 #     cpu: 500m

--- a/tavros/camel-web-service/values.yaml
+++ b/tavros/camel-web-service/values.yaml
@@ -53,7 +53,7 @@ livenessProbe:
   initialDelaySeconds: 60
   periodSeconds: 10
 
-# resources:
+resources: {}
 #   limits:
 #     cpu: 500m
 #     memory: 1Gi


### PR DESCRIPTION
want to add startup probe functionality for apps that have longer than normal startup time

tested in local (not Tavros) cluster with `helm install camel-web-service .`