### PR TITLE
Resolve #7

### DIFF
--- a/tavros/camel-web-service/Chart.yaml
+++ b/tavros/camel-web-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/tavros/camel-web-service/templates/deployment.yaml
+++ b/tavros/camel-web-service/templates/deployment.yaml
@@ -49,9 +49,6 @@ spec:
             - name: actuator
               containerPort: 8080
               protocol: TCP
-            - name: hb-monitor
-              containerPort: 19001
-              protocol: TCP
         {{- with .Values.readinessProbe }}
           readinessProbe:
             {{- toYaml . | nindent 12 }}

--- a/tavros/camel-web-service/templates/service.yaml
+++ b/tavros/camel-web-service/templates/service.yaml
@@ -22,9 +22,5 @@ spec:
       port: 8080
       protocol: TCP
       targetPort: 8080
-    - name: kuma-virtual-probe
-      port: 19001
-      protocol: TCP
-      targetPort: 19001
   selector:
     {{- include "camel-web-service.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Info is in #7. Removal of duplicate ports resolves ongoing issues with kuma, but will create breaking change for heartbeat/uptime monitoring in Elastic. Additional issue will be created in Tavros repo related to that, as users won't need to upgrade to this version right away.